### PR TITLE
fix sample generating error due to keyword args

### DIFF
--- a/modules/sample_callback.py
+++ b/modules/sample_callback.py
@@ -13,7 +13,8 @@ from .utils import rename_keys
 
 
 class SampleCallback(pl.Callback):
-    _CONFIG_TRANSFORM = {"cfg_scale": "guidance_scale", "steps": "num_inference_steps"}
+    _CONFIG_TRANSFORM = {"cfg_scale": "guidance_scale", "steps": "num_inference_steps",
+            "num_samples": None, "seed": None}
 
     def __init__(self, sample_save_dir: str | PathLike):
         self.sample_dir = Path(sample_save_dir)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -23,7 +23,7 @@ def read_image(filepath: Path) -> Image.Image:
 
 
 def rename_keys(source: dict, key_dict: dict):
-    return {key_dict.get(k, k): v for k, v in source.items()}
+    return {key_dict.get(k, k): v for k, v in source.items() if key_dict.get(k, "") != None}
 
 
 def get_class(name: str):


### PR DESCRIPTION
Fixes errors when generating samples:

```
TypeError: StableDiffusionPipeline.__call__() got an unexpected keyword argument 'num_samples'
```

and

```
TypeError: StableDiffusionPipeline.__call__() got an unexpected keyword argument 'seed'
```